### PR TITLE
Reimplement os.system() as subprocess.run()

### DIFF
--- a/command_server.py
+++ b/command_server.py
@@ -10,11 +10,12 @@
 #           recieves robot commands via POST and performs the corresponding command
 #-------------------------------------------------------------------
 from flask import Flask, request, jsonify
-import os
+import subprocess
 import data_collection
 
 server = Flask(__name__)
 
+ros2_path = '/opt/ros/humble/bin/ros2'
 
 @server.route('/api/status')
 def get_status():
@@ -32,7 +33,10 @@ def webhook():
             match content.get('SIGMAP-CMD'):
                 case 'Undock':
                     print('Undock Command Recieved!')
-                    os.system(f'ros2 action send_goal /undock irobot_create_msgs/action/Undock "{{}}"')
+                    try:
+                        undock_action = subprocess.run([ros2_path, 'action', 'send_goal', '/undock', 'irobot_create_msgs/action/Undock', '{}'])
+                    except KeyboardInterrupt:
+                        pass
                     print('Undock command executed')
                     return "Undock Executed"
                 case _:


### PR DESCRIPTION
os.system() is not the correct way of running shell commands via python. subprocess prevents shell injection as well as reduces performance overhead. We can also use subprocess to parse stdout in the future.